### PR TITLE
UI update (and some other stuff)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+# Digit Collector
+An attempt to bring one of aarex's side projects into reality before 2021.

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 	}
 		
 	.unavailable {
-		opacity: 0;
+		opacity: 0.5;
 	}
 	
 	</style>
@@ -104,7 +104,7 @@
 				if(a.lt(1e33)) return format(a,0);
 				else return format(a,1);
 			}
-			if (n==5) return "ee"+Decimal.log10(a.log10().max(1)).toFixed(5)
+			if (n==5) return "ee"+Decimal.log10(Math.max(a.log10(), 1)).toFixed(5)
 		}
 
 		function format2(a,n) { // Format while removing decimal places.
@@ -415,8 +415,8 @@
 			<button id="optionsTabButton" onclick="switchTab('options')">Options</button>
 		</div>
 		<div id = "prestige" style = "text-align: center; margin: 10px">
-			<button id="addButton" style="display:none" onclick="addDigits()">Add your digits to boost your production.<br>Gain <span id="plusesToBeGained">1</span> pluses.</div></button>
-			<button id="multiplyButton" style="display:none" onclick="multiplyNumbers()">Multiply your numbers to gain upgrades.<br>Gain <span id="crossesToBeGained">1</span> crosses.</div></button>
+			<button id="addButton" style="display:none" onclick="addDigits()">Add your digits to boost your production.<br>Gain <span id="plusesToBeGained">1</span> pluses.</button>
+			<button id="multiplyButton" style="display:none" onclick="multiplyNumbers()">Multiply your numbers to gain upgrades.<br>Gain <span id="crossesToBeGained">1</span> crosses.</button>
 		</div>
 		<div id="digits">
 			<button id="maxAllButton" onclick="maxAllDigits()">Max all</button>

--- a/index.html
+++ b/index.html
@@ -123,7 +123,7 @@
 
 		function maxAllDigits() { // buys max of all unlocked digits.
 			for(var i=0; i<=player.digitShifts; i++) {
-				while(player.numbers[i] >= player.digitCosts[i] {
+				while(player.numbers[i] >= player.digitCosts[i]) {
 					buyDigit(i);
 				}
 			}

--- a/index.html
+++ b/index.html
@@ -156,7 +156,8 @@
 		}
 
 		function multiplyNumbers() { // prestige 2
-			showElement("multiplicationTabButton")
+			showElement("multiplicationTabButton");
+			hideElement("additionTabButton");
 			
 			player.crosses = player.crosses.add(Decimal.pow(player.pluses/1000000,0.5).floor());
 			resetPlayer(2) // reset digits and addition content
@@ -182,7 +183,7 @@
 				update("crossesToBeGained",format2(Decimal.pow(player.pluses/1000000,0.5).floor(),player.notation));
 			}
 			if(player.pluses.gt(0) || player.digitMults[0].gt(1)) showElement("additionTabButton");
-			if(player.crosses.gt(0)) showelement("multiplicationTabButton");
+			if(player.crosses.gt(0)) showElement("multiplicationTabButton");
 			// These lines are here to enforce the display to match the stored variable.
 			for(var i=0;i<10;i++) {
 				update(i+"sDisplay",format(player.numbers[i],player.notation));

--- a/index.html
+++ b/index.html
@@ -303,7 +303,7 @@
 		</div>
 		<div id = "prestige" style = "text-align: center; margin: 10px">
 			<button id="addButton" style="display:none" onclick="addDigits()">Add your digits to boost your production.<br>Gain <span id="plusesToBeGained">1</span> pluses.</div></button>
-			<button id="multiplyButton" style="display:none" onclick="multiplyNumbers()">Muiliply your numbers to gain upgrades.<br>Gain <span id="crossesToBeGained">1</span> crosses.</div></button>
+			<button id="multiplyButton" style="display:none" onclick="multiplyNumbers()">Multiply your numbers to gain upgrades.<br>Gain <span id="crossesToBeGained">1</span> crosses.</div></button>
 		</div>
 		<div id="digits">
 			<table>

--- a/index.html
+++ b/index.html
@@ -194,7 +194,7 @@
 				if(player.numberUpgradeCosts[0].gt(player.crosses)) return 0; // can't buy it
 				player.u1 = player.u1.multiply(1.5);
 				for(var i=0; i<=9; i++) {
-					player.digitMults[i] = player.digitMults[i].multiply(1.5)); // update all digit multipliers
+					player.digitMults[i] = player.digitMults[i].multiply(1.5); // update all digit multipliers
 				}
 				player.numberUpgradeCosts[0] = player.numberUpgradeCosts[0].multiply(8); // increase cost
 				break;

--- a/index.html
+++ b/index.html
@@ -153,6 +153,14 @@
 			player.nps[i] = player.nps[i].multiply(2);
 		}
 
+		function maxAllDigitUpgrades() { // buys max upgrades of all digits. Prioritizes lower digits over higher ones so as to get the single biggest multiplier to overall production (and thus, gain of pluses).
+			for(var i=0; i<=player.digitShifts; i++) {
+				while(player.numbers[i].gte(player.digitUpgradeCosts[i])) {
+					upgradeDigit(i);
+				}
+			}
+		}
+
 		function digitShift() {
 			if(player.digitShiftCost.gt(player.pluses)) return 0; // don't have enough
 			player.pluses = player.pluses.subtract(player.digitShiftCost);
@@ -166,6 +174,9 @@
 		function multiplyNumbers() { // prestige 2
 			showElement("multiplicationTabButton");
 			hideElement("additionTabButton");
+			for(var i=1; i<=9; i++) {
+				hideElement("d"+i+"row");
+			}
 			
 			player.crosses = player.crosses.add(Decimal.pow(player.pluses/1000000,0.5).floor());
 			resetPlayer(2) // reset digits and addition content
@@ -395,6 +406,7 @@
 		</div>
 		<div style="display:none" id="addition">
 			<p>You have <span id="plusesDisplay" style = "font-size: 24">0</span> pluses.
+			<button id="maxUpgradesButton" onclick="maxAllDigitUpgrades()">Max all</button>
 			<table>
 				<tr>
 					<td><button id="d0UpgradeButton" onclick="upgradeDigit(0)">Double digit 0 production.<br>Current bonus: x<span id="d0multDisplay">1</span>.<br>Cost: <span id="d0UpgradeCostDisplay">1</span> pluses.</button></td>

--- a/index.html
+++ b/index.html
@@ -429,17 +429,17 @@
 			<table>
 				<tr>
 					<td><button>All digits produce 2x faster.<br>Current boost: x1.<br>Cost: 1 crosses.</button></td>
-					<td>Each digit gains a 1.04x production multiplier for each of that digit you buy.<br>Cost: 2 crosses.</button></td>
+					<td><button>Each digit gains a 1.04x production multiplier for each of that digit you buy.<br>Cost: 2 crosses.</button></td>
 					<td><button>Each subsequent digit is 0.7x as strong as the previous instead of 0.5x.<br>Cost: 5 crosses.</button></td>
 				</tr>
 				<tr>
 					<td><button>Digit upgrades make digits 4x faster instead of 2x.<br>Cost: 10 crosses.</button></td>
-					<td>You start with all digits unlocked after multiplication.<br>Cost: 50 crosses.</button></td>
+					<td><button>You start with all digits unlocked after multiplication.<br>Cost: 50 crosses.</button></td>
 					<td><button>You gain 2x more pluses.<br>Current boost: x1.<br>Cost: 100 crosses.</button></td>
 				</tr>
 				<tr>
 					<td><button>Install Digit Buy D.I.G.I.T.S.<br>Cost: 5 crosses.</button></td>
-					<td>Install Digit Upgrade d.I.G.I.T.S.<br>Cost: 50 crosses.</button></td>
+					<td><button>Install Digit Upgrade d.I.G.I.T.S.<br>Cost: 50 crosses.</button></td>
 					<td><button>Install Digit Add d.I.G.I.T.S.<br>Cost: 100 crosses.</button></td>
 				</tr>
 			</table>

--- a/index.html
+++ b/index.html
@@ -426,6 +426,23 @@
 		</div>
 		<div style="display:none" id="multiplication">
 			<p>You have <span id="crossesDisplay" style = "font-size: 24">0</span> crosses.
+			<table>
+				<tr>
+					<td><button>All digits produce 2x faster.<br>Current boost: x1.<br>Cost: 1 crosses.</button></td>
+					<td>Each digit gains a 1.04x production multiplier for each of that digit you buy.<br>Cost: 2 crosses.</button></td>
+					<td><button>Each subsequent digit is 0.7x as strong as the previous instead of 0.5x.<br>Cost: 5 crosses.</button></td>
+				</tr>
+				<tr>
+					<td><button>Digit upgrades make digits 4x faster instead of 2x.<br>Cost: 10 crosses.</button></td>
+					<td>You start with all digits unlocked after multiplication.<br>Cost: 50 crosses.</button></td>
+					<td><button>You gain 2x more pluses.<br>Current boost: x1.<br>Cost: 100 crosses.</button></td>
+				</tr>
+				<tr>
+					<td><button>Install Digit Buy D.I.G.I.T.S.<br>Cost: 5 crosses.</button></td>
+					<td>Install Digit Upgrade d.I.G.I.T.S.<br>Cost: 50 crosses.</button></td>
+					<td><button>Install Digit Add d.I.G.I.T.S.<br>Cost: 100 crosses.</button></td>
+				</tr>
+			</table>
 		</div>
 <a style = "position: absolute; left: 20; bottom: 20" href="https://discord.gg/RR2kv5">Discord</a>
 	</body>

--- a/index.html
+++ b/index.html
@@ -455,7 +455,7 @@
 			<p>You have <span id="crossesDisplay" style = "font-size: 24">0</span> crosses.
 			<table>
 				<tr>
-					<td><button id="u1button">All digits produce 1.5x faster.<br>Current boost: x<span id="u1Display">1</span>.<br>Cost: <span id="u1costDisplay">1</span> crosses.</button></td>
+					<td><button id="u1button" onclick="buyNumberUpgrade(1)>All digits produce 1.5x faster.<br>Current boost: x<span id="u1Display">1</span>.<br>Cost: <span id="u1costDisplay">1</span> crosses.</button></td>
 					<td><button>Each digit gains a 1.04x production multiplier for each of that digit you buy.<br>Cost: 3 crosses.</button></td>
 					<td><button>Each subsequent digit is 0.7x as strong as the previous instead of 0.5x.<br>Cost: 5 crosses.</button></td>
 				</tr>

--- a/index.html
+++ b/index.html
@@ -158,7 +158,7 @@
 
 		function maxAllDigitUpgrades() { // buys max upgrades of all digits. Prioritizes lower digits over higher ones so as to get the single biggest multiplier to overall production (and thus, gain of pluses).
 			for(var i=0; i<=player.digitShifts; i++) {
-				while(player.numbers[i].gte(player.digitUpgradeCosts[i])) {
+				while(player.pluses.gte(player.digitUpgradeCosts[i])) {
 					upgradeDigit(i);
 				}
 			}

--- a/index.html
+++ b/index.html
@@ -103,7 +103,7 @@
 				player.digitCosts = decimalArray(10, 10, 1)
 			}
 			if(layers >= 2) { // reset addition
-				player.digitMults = decimalArray(10, player.u1power, 0.5) // keeps affects of number upgrades, but not digit upgrades
+				player.digitMults = decimalArray(10, player.u1, 0.5) // keeps affects of number upgrades, but not digit upgrades
 				player.digitUpgradeCosts = decimalArray(10, 1, 8)
 				player.pluses = new Decimal(0)
 				player.digitShifts = 0
@@ -235,9 +235,9 @@
 			update("digitShiftCostDisplay",format2(player.digitShiftCost,player.notation));
 			if(player.nextDigit >= 10) hideElement("digitShiftButton"); // 9 is the last digit shift
 			update("crossesDisplay",format2(player.crosses,player.notation));
-			update("u1costDisplay",player.numberUpgradeCosts[0]); 
+			update("u1costDisplay",format2(player.numberUpgradeCosts[0])); 
 			// only upgrades 1 and 6 should ever change cost.
-			update("u1Display",player.u1);
+			update("u1Display",format(player.u1));
 		}
 
 		function hardReset() {
@@ -298,7 +298,7 @@
 				for(var i = 0; i<=9; i++) {
 					player.numberUpgradeCosts[i] = new Decimal(player.numberUpgradeCosts[i]);
 				}
-				player.ua = new Decimal(player.u1);
+				player.u1 = new Decimal(player.u1);
 				
 				// Update UI
 				

--- a/index.html
+++ b/index.html
@@ -121,6 +121,14 @@
 			player.nps[i] = player.digitAmounts[i].multiply(player.digitMults[i]); // this will be how many numbers we get per tick
 		}
 
+		function maxAllDigits() { // buys max of all unlocked digits.
+			for(var i=0; i<=player.digitShifts; i++) {
+				while(player.numbers[i] >= player.digitCosts[i] {
+					buyDigit(i);
+				}
+			}
+		}
+
 		function getPluses() { // code to determine how many pluses we should get when adding digits
 			var temp = new Decimal(1); // storage variable
 			for(var i=0; i<player.nextDigit; i++) {
@@ -306,6 +314,7 @@
 			<button id="multiplyButton" style="display:none" onclick="multiplyNumbers()">Multiply your numbers to gain upgrades.<br>Gain <span id="crossesToBeGained">1</span> crosses.</div></button>
 		</div>
 		<div id="digits">
+			<button id="maxAllButton" onclick="maxAllDigits()">Max all</button>
 			<table>
 				<tr>
 					<th>Number</th>

--- a/index.html
+++ b/index.html
@@ -455,7 +455,7 @@
 			<p>You have <span id="crossesDisplay" style = "font-size: 24">0</span> crosses.
 			<table>
 				<tr>
-					<td><button id="u1button" onclick="buyNumberUpgrade(1)>All digits produce 1.5x faster.<br>Current boost: x<span id="u1Display">1</span>.<br>Cost: <span id="u1costDisplay">1</span> crosses.</button></td>
+					<td><button id="u1button" onclick="buyNumberUpgrade(1)">All digits produce 1.5x faster.<br>Current boost: x<span id="u1Display">1</span>.<br>Cost: <span id="u1costDisplay">1</span> crosses.</button></td>
 					<td><button>Each digit gains a 1.04x production multiplier for each of that digit you buy.<br>Cost: 3 crosses.</button></td>
 					<td><button>Each subsequent digit is 0.7x as strong as the previous instead of 0.5x.<br>Cost: 5 crosses.</button></td>
 				</tr>

--- a/index.html
+++ b/index.html
@@ -1,4 +1,20 @@
 <html>
+	<style>
+	
+	button {
+		transition-duration: 0.2s;
+	}
+		
+	.available {
+		opacity: 1;
+	}
+		
+	.unavailable {
+		opacity: 0;
+	}
+	
+	</style>
+	
 	<head>
 		<title>Digit Collector</title>
 		<script type="text/javascript" src="logarithmica_numerus_lite.js"></script>
@@ -65,7 +81,7 @@
 			return ret;
 		}
 
-		function format(a,n) { // format number a in notation n (see var notationArray for a list of notations
+		function format(a,n=player.notation) { // format number a in notation n (see var notationArray for a list of notations
 			a = new Decimal(a); // make it a Decimal, if it isn't already.
 			if (a.lt(10)) return a.toFixed(3);
 			if (a.lt(100)) return a.toFixed(2);
@@ -73,19 +89,22 @@
 			var m = Math.round(1000*Math.pow(10,a.log10()-Math.floor(a.log10())))/1000; // mantissa of number, rounded to three decimal places
 			var e = Math.floor(a.log10()); // exponent of number
 			if (m>9.9995) { // would this mantissa cause the value to round up to 10.000? If so, prevent it.
-			m = 1;
-			e++;
-	}
-			if (n==1) return m+"e"+e; // scientific notation
-			if (n==3) return "e"+Math.round(1000*a.log10())/1000; // logarithm notation
-			var e2 = 3*Math.floor(e/3);
-			var m2 = Math.round(1000*m*Math.pow(10,e-e2))/1000; // values for standard and engineering
-			if(n==0) return m2+abbreviate(e2/3-1);
-			if(n==2) return m2+"e"+e2;
-				if(n==4) { // mixed scientific notation
-			if(a.lt(1e33)) return format(a,0);
-			else return format(a,1);
+				m = 1;
+				e++;
 			}
+			
+			var e2 = 3*Math.floor(e/3);
+			var m2 = (m*Math.pow(10,e-e2)).toFixed(3); // values for standard and engineering
+			
+			if (n==0) return m2+abbreviate(e2/3-1); // standard notation
+			if (n==1) return m+"e"+e; // scientific notation
+			if (n==2) return m2+"e"+e2;
+			if (n==3) return "e"+a.log10().toFixed(3); // logarithm notation
+			if (n==4) { // mixed scientific notation
+				if(a.lt(1e33)) return format(a,0);
+				else return format(a,1);
+			}
+			if (n==5) return "ee"+Decimal.log10(a.log10().max(1)).toFixed(5)
 		}
 
 		function format2(a,n) { // Format while removing decimal places.
@@ -277,6 +296,13 @@
 			update("u1costDisplay",format2(player.numberUpgradeCosts[0],player.notation)); 
 			// only upgrades 1 and 6 should ever change cost.
 			update("u1Display",format(player.u1,player.notation));
+			
+			// Update UI
+			
+			for(var i = 0; i < 10; i++) {
+				document.getElementById("d" + i + "button").className = player.digitCosts[i].lte(player.numbers[i]) ? "available" : "unavailable"
+				document.getElementById("d" + i + "UpgradeButton").className = player.digitUpgradeCosts[i].lte(player.pluses) ? "available" : "unavailable"
+			}
 		}
 
 		function hardReset() {
@@ -287,13 +313,13 @@
 			}
 		}
 
-		var notationArray = ["Standard","Scientific","Engineering","Logarithm","Mixed scientific"]; // list of implemented notations, used by the next function
+		var notationArray = ["Standard","Scientific","Engineering","Logarithm","Mixed scientific","Double-logarithm"]; // list of implemented notations, used by the next function
 
 		function switchNotation() {
 			player.notation++;
 			if(player.notation>notationArray.length-1) player.notation=0;
 			update("notationDisplay",notationArray[player.notation]);
-}
+		}
 
 		function save() {
 			localStorage.setItem('DCSave',btoa(JSON.stringify(player)))
@@ -481,6 +507,8 @@
 					<td><button id="d2UpgradeButton" onclick="upgradeDigit(2)" style="display:none">Double digit 2 production.<br>Current bonus: x<span id="d2multDisplay">0.25</span>.<br>Cost: <span id="d2UpgradeCostDisplay">64</span> pluses.</button></td>
 					<td><button id="d3UpgradeButton" onclick="upgradeDigit(3)" style="display:none">Double digit 3 production.<br>Current bonus: x<span id="d3multDisplay">0.125</span>.<br>Cost: <span id="d3UpgradeCostDisplay">512</span> pluses.</button></td>
 					<td><button id="d4UpgradeButton" onclick="upgradeDigit(4)" style="display:none">Double digit 4 production.<br>Current bonus: x<span id="d4multDisplay">0.063</span>.<br>Cost: <span id="d4UpgradeCostDisplay">4096</span> pluses.</button></td>
+				</tr>
+				<tr>
 					<td><button id="d5UpgradeButton" onclick="upgradeDigit(5)" style="display:none">Double digit 5 production.<br>Current bonus: x<span id="d5multDisplay">0.031</span>.<br>Cost: <span id="d5UpgradeCostDisplay">32768</span> pluses.</button></td>
 					<td><button id="d6UpgradeButton" onclick="upgradeDigit(6)" style="display:none">Double digit 6 production.<br>Current bonus: x<span id="d6multDisplay">0.016</span>.<br>Cost: <span id="d6UpgradeCostDisplay">262144</span> pluses.</button></td>
 					<td><button id="d7UpgradeButton" onclick="upgradeDigit(7)" style="display:none">Double digit 7 production.<br>Current bonus: x<span id="d7multDisplay">0.008</span>.<br>Cost: <span id="d7UpgradeCostDisplay">2097152</span> pluses.</button></td>
@@ -506,8 +534,8 @@
 				</tr>
 				<tr>
 					<td><button>Install Digit Buy D.I.G.I.T.S.<br>Cost: 5 crosses.</button></td>
-					<td><button>Install Digit Upgrade d.I.G.I.T.S.<br>Cost: 50 crosses.</button></td>
-					<td><button>Install Digit Add d.I.G.I.T.S.<br>Cost: 100 crosses.</button></td>
+					<td><button>Install Digit Upgrade D.I.G.I.T.S.<br>Cost: 50 crosses.</button></td>
+					<td><button>Install Digit Add D.I.G.I.T.S.<br>Cost: 100 crosses.</button></td>
 				</tr>
 			</table>
 		</div>

--- a/index.html
+++ b/index.html
@@ -123,7 +123,7 @@
 
 		function maxAllDigits() { // buys max of all unlocked digits.
 			for(var i=0; i<=player.digitShifts; i++) {
-				while(player.numbers[i] >= player.digitCosts[i]) {
+				while(player.numbers[i].gte(player.digitCosts[i])) {
 					buyDigit(i);
 				}
 			}

--- a/index.html
+++ b/index.html
@@ -92,7 +92,8 @@
 			notation:0,
 			crosses:new Decimal(0),
 			numberUpgradeCosts:[new Decimal(1),new Decimal(3),new Decimal(5),new Decimal(10),new Decimal(50),new Decimal(100),new Decimal(5),new Decimal(50),new Decimal(100)],
-			u1:new Decimal(1)
+			u1:new Decimal(1),
+			u2:false
 		}
 		
 		function resetPlayer(layers) {
@@ -113,6 +114,9 @@
 			if(layers >= 3) { // reset multiplication
 				player.digitMults = decimalArray(10, 1, 0.5)
 				player.crosses = new Decimal(0);
+				player.numberUpgradeCosts = [new Decimal(1),new Decimal(3),new Decimal(5),new Decimal(10),new Decimal(50),new Decimal(100),new Decimal(5),new Decimal(50),new Decimal(100)],
+				player.u1 = new Decimal(1),
+			player.u2 = false
 			}
 		}
 
@@ -122,6 +126,7 @@
 			player.digitCosts[i] = player.digitCosts[i].multiply(2); // make the next digit cost more
 			player.digitAmounts[i] = player.digitAmounts[i].add(1); // one more digit
 			player.nps[i] = player.digitAmounts[i].multiply(player.digitMults[i]); // this will be how many numbers we get per tick
+			if(player.u2) player.digitMults[i] = player.digitMults[i].multiply(1.04); // apply the affects of number upgrade 2
 		}
 
 		function maxAllDigits() { // buys max of all unlocked digits.
@@ -144,6 +149,11 @@
 			showElement("additionTabButton")
 			
 			player.pluses = player.pluses.add(getPluses()); // give player gained pluses
+			if(player.u2) { // if he has upgrade 2, make sure to reset mults from it.
+				for(var i=0; i<=player.digitShifst; i++) {
+					player.digitMults[i] = player.digitMults[i].divide(Decimal.pow(1.04,player.digitAmounts[i]));
+				}
+			}
 			resetPlayer(1) // reset digits
 			hideElement("addButton")
 		}
@@ -190,6 +200,7 @@
 		function buyNumberUpgrade(i) { // buys number upgrade i.
 			switch(i) { 
 				// n what follows, there should be one case for each number upgrade in the game (9 total). 
+				
 				case 1:
 				if(player.numberUpgradeCosts[0].gt(player.crosses)) return 0; // can't buy it
 				player.crosses = player.crosses.subtract(player.numberUpgradeCosts[0]);
@@ -199,7 +210,18 @@
 				}
 				player.numberUpgradeCosts[0] = player.numberUpgradeCosts[0].multiply(8); // increase cost
 				break;
-				// Todo: add cases 2-9
+				
+				case 2:
+				if(player.u2) return 0; // already bought it once; don't do anything if he clicks it again
+				if(player.numberUpgradeCosts[1].gt(player.crosses)) return 0; // can't buy it
+				player.crosses = player.crosses.subtract(player.numberUpgradeCosts[1]);
+				player.u2 = true;
+				for(var i=0; i<=player.digitShifts; i++) {
+					player.digitMults[i] = player.digitMults[i].multiply(Decimal.pow(1.04,player.digitAmounts[i])); // in case he bought it mid-run, apply retroactively.
+				}
+				break;
+				
+				// Todo: add cases 3-9
 			}
 		}
 
@@ -236,9 +258,9 @@
 			update("digitShiftCostDisplay",format2(player.digitShiftCost,player.notation));
 			if(player.nextDigit >= 10) hideElement("digitShiftButton"); // 9 is the last digit shift
 			update("crossesDisplay",format2(player.crosses,player.notation));
-			update("u1costDisplay",format2(player.numberUpgradeCosts[0])); 
+			update("u1costDisplay",format2(player.numberUpgradeCosts[0],player.notation)); 
 			// only upgrades 1 and 6 should ever change cost.
-			update("u1Display",format(player.u1));
+			update("u1Display",format(player.u1,player.notation));
 		}
 
 		function hardReset() {
@@ -282,6 +304,7 @@
 				if(player.crosses===undefined) player.crosses = new Decimal(0);
 				if(player.numberUpgradeCosts===undefined) player.numberUpgradeCosts = [new Decimal(1),new Decimal(3),new Decimal(5),new Decimal(10),new Decimal(50),new Decimal(100),new Decimal(5),new Decimal(50),new Decimal(100)];
 				if(player.u1===undefined) player.u1 = new Decimal(1);
+				if(player.u2===undefined) player.u2 = false;
 				
 				// Convert save to decimal
 				
@@ -457,7 +480,7 @@
 			<table>
 				<tr>
 					<td><button id="u1button" onclick="buyNumberUpgrade(1)">All digits produce 1.5x faster.<br>Current boost: x<span id="u1Display">1</span>.<br>Cost: <span id="u1costDisplay">1</span> crosses.</button></td>
-					<td><button>Each digit gains a 1.04x production multiplier for each of that digit you buy.<br>Cost: 3 crosses.</button></td>
+					<td><button id="u2button" onclick="buyNumberUpgrade(2)">Each digit gains a 1.04x production multiplier for each of that digit you buy.<br>Cost: 3 crosses.</button></td>
 					<td><button>Each subsequent digit is 0.7x as strong as the previous instead of 0.5x.<br>Cost: 5 crosses.</button></td>
 				</tr>
 				<tr>

--- a/index.html
+++ b/index.html
@@ -34,19 +34,35 @@
 			return a
 		}
 
-		function abbreviate(i) { // get standard notation abbreviation for the i-th illion. (Currently only works properly to i = 999.)
-		if(i==0) return "K";
+		function abbreviate(i) { // get standard notation abbreviation for the i-th illion.
+			if(i==0) return "K";
 			if(i==1) return "M";
 			if(i==2) return "B";
 			var units = ["","U","Du","T","Qa","Qt","Sx","Sp","O","N"];
 			var tens = ["","Dc","Vg","Tg","Qd","Qi","Se","St","Og","Nn"];
-			var hundreds = ["","Ce","Dn","Tc","Qe","Qu","Sc","Si","Oe","Ne"]
+			var hundreds = ["","Ce","Dn","Tc","Qe","Qu","Sc","Si","Oe","Ne"];
 			var i2 = Math.floor(i/10);
 			var i3 = Math.floor(i2/10);
 			var unit = units[i%10];
 			var ten = tens[i2%10];
 			var hundred = hundreds[i3%10];
-			return unit+ten+hundred;
+			
+			// -illions greater than 999
+			
+			var mi = Math.floor((i%1e6)/1e3);
+			var mc = Math.floor((i%1e9)/1e6);
+			var na = Math.floor((i%1e12)/1e9);
+			var pc = Math.floor((i%1e15)/1e12);
+			var fm = Math.floor((i%1e18)/1e15);
+			
+			var ret = "";
+			if(pc > 0) ret += abbreviate(pc) + "PC-";
+			if(na > 0) ret += abbreviate(na) + "NA-";
+			if(mc > 0) ret += abbreviate(mc) + "MC-";
+			if(mi > 0) ret += abbreviate(mi) + "MI-";
+			ret += unit+ten+hundred;
+			
+			return ret;
 		}
 
 		function format(a,n) { // format number a in notation n (see var notationArray for a list of notations
@@ -57,8 +73,8 @@
 			var m = Math.round(1000*Math.pow(10,a.log10()-Math.floor(a.log10())))/1000; // mantissa of number, rounded to three decimal places
 			var e = Math.floor(a.log10()); // exponent of number
 			if (m>9.9995) { // would this mantissa cause the value to round up to 10.000? If so, prevent it.
-		m = 1;
-		e++;
+			m = 1;
+			e++;
 	}
 			if (n==1) return m+"e"+e; // scientific notation
 			if (n==3) return "e"+Math.round(1000*a.log10())/1000; // logarithm notation

--- a/index.html
+++ b/index.html
@@ -90,7 +90,9 @@
 			nextDigit:1,
 			digitShiftCost:new Decimal(4),
 			notation:0,
-			crosses:new Decimal(0)
+			crosses:new Decimal(0),
+			numberUpgradeCosts:[new Decimal(1),new Decimal(3),new Decimal(5),new Decimal(10),new Decimal(50),new Decimal(100),new Decimal(5),new Decimal(50),new Decimal(100)],
+			u1:new Decimal(1)
 		}
 		
 		function resetPlayer(layers) {
@@ -101,7 +103,7 @@
 				player.digitCosts = decimalArray(10, 10, 1)
 			}
 			if(layers >= 2) { // reset addition
-				player.digitMults = decimalArray(10, 1, 0.5)
+				player.digitMults = decimalArray(10, player.u1power, 0.5) // keeps affects of number upgrades, but not digit upgrades
 				player.digitUpgradeCosts = decimalArray(10, 1, 8)
 				player.pluses = new Decimal(0)
 				player.digitShifts = 0
@@ -109,6 +111,7 @@
 				player.digitShiftCost = new Decimal(4)
 			}
 			if(layers >= 3) { // reset multiplication
+				player.digitMults = decimalArray(10, 1, 0.5)
 				player.crosses = new Decimal(0);
 			}
 		}
@@ -184,6 +187,21 @@
 			hideElement("multiplyButton");
 		}
 
+		function buyNumberUpgrade(i) { // buys number upgrade i.
+			switch(i) { 
+				// n what follows, there should be one case for each number upgrade in the game (9 total). 
+				case 1:
+				if(player.numberUpgradeCosts[0].gt(player.crosses)) return 0; // can't buy it
+				player.u1 = player.u1.multiply(1.5);
+				for(var i=0; i<=9; i++) {
+					player.digitMults[i] = player.digitMults[i].multiply(1.5)); // update all digit multipliers
+				}
+				player.numberUpgradeCosts[0] = player.numberUpgradeCosts[0].multiply(8); // increase cost
+				break;
+				// Todo: add cases 2-9
+			}
+		}
+
 		function tick(t) {
 			diff = Date.now() - player.lastUpdate;
 			player.lastUpdate = Date.now();
@@ -202,7 +220,7 @@
 				update("crossesToBeGained",format2(Decimal.pow(player.pluses/1000000,0.5).floor(),player.notation));
 			}
 			if(player.pluses.gt(0) || player.digitMults[0].gt(1)) showElement("additionTabButton");
-			if(player.crosses.gt(0)) showElement("multiplicationTabButton");
+			if(player.crosses.gt(0) || player.u1.gt(1)) showElement("multiplicationTabButton");
 			// These lines are here to enforce the display to match the stored variable.
 			for(var i=0;i<10;i++) {
 				update(i+"sDisplay",format(player.numbers[i],player.notation));
@@ -217,6 +235,9 @@
 			update("digitShiftCostDisplay",format2(player.digitShiftCost,player.notation));
 			if(player.nextDigit >= 10) hideElement("digitShiftButton"); // 9 is the last digit shift
 			update("crossesDisplay",format2(player.crosses,player.notation));
+			update("u1costDisplay",player.upgradeCosts[0]); 
+			// only upgrades 1 and 6 should ever change cost.
+			update("u1Display",player.u1);
 		}
 
 		function hardReset() {
@@ -258,6 +279,8 @@
 				if(player.lastUpdate===undefined) player.lastUpdate = Date.now();
 				if (player.notation===undefined) player.notation=0; // Yes, you start in standard notation. Deal with it.
 				if(player.crosses===undefined) player.crosses = new Decimal(0);
+				if(player.numberUpgradeCosts===undefined) player.numberUpgradeCosts = [new Decimal(1),new Decimal(3),new Decimal(5),new Decimal(10),new Decimal(50),new Decimal(100),new Decimal(5),new Decimal(50),new Decimal(100)];
+				if(player.u1===undefined) player.u1 = new Decimal(1);
 				
 				// Convert save to decimal
 				
@@ -272,6 +295,10 @@
 				player.pluses = new Decimal(player.pluses)
 				player.digitShiftCost = new Decimal(player.digitShiftCost)
 				player.crosses = new Decimal(player.crosses)
+				for(var i = 0; i<=9; i++) {
+					player.numberUpgradeCosts[i] = new Decimal(player.numberUpgradeCosts[i]);
+				}
+				player.ua = new Decimal(player.u1);
 				
 				// Update UI
 				
@@ -428,8 +455,8 @@
 			<p>You have <span id="crossesDisplay" style = "font-size: 24">0</span> crosses.
 			<table>
 				<tr>
-					<td><button>All digits produce 2x faster.<br>Current boost: x1.<br>Cost: 1 crosses.</button></td>
-					<td><button>Each digit gains a 1.04x production multiplier for each of that digit you buy.<br>Cost: 2 crosses.</button></td>
+					<td><button id="u1button">All digits produce 1.5x faster.<br>Current boost: x<span id="u1Display">1</span>.<br>Cost: <span id="u1costDisplay">1</span> crosses.</button></td>
+					<td><button>Each digit gains a 1.04x production multiplier for each of that digit you buy.<br>Cost: 3 crosses.</button></td>
 					<td><button>Each subsequent digit is 0.7x as strong as the previous instead of 0.5x.<br>Cost: 5 crosses.</button></td>
 				</tr>
 				<tr>

--- a/index.html
+++ b/index.html
@@ -260,6 +260,7 @@
 				}
 				player.pluses = new Decimal(player.pluses)
 				player.digitShiftCost = new Decimal(player.digitShiftCost)
+				player.crosses = new Decimal(player.crosses)
 				
 				// Update UI
 				

--- a/index.html
+++ b/index.html
@@ -235,7 +235,7 @@
 			update("digitShiftCostDisplay",format2(player.digitShiftCost,player.notation));
 			if(player.nextDigit >= 10) hideElement("digitShiftButton"); // 9 is the last digit shift
 			update("crossesDisplay",format2(player.crosses,player.notation));
-			update("u1costDisplay",player.upgradeCosts[0]); 
+			update("u1costDisplay",player.numberUpgradeCosts[0]); 
 			// only upgrades 1 and 6 should ever change cost.
 			update("u1Display",player.u1);
 		}

--- a/index.html
+++ b/index.html
@@ -192,6 +192,7 @@
 				// n what follows, there should be one case for each number upgrade in the game (9 total). 
 				case 1:
 				if(player.numberUpgradeCosts[0].gt(player.crosses)) return 0; // can't buy it
+				player.crosses = player.crosses.subtract(player.numberUpgradeCosts[0]);
 				player.u1 = player.u1.multiply(1.5);
 				for(var i=0; i<=9; i++) {
 					player.digitMults[i] = player.digitMults[i].multiply(1.5); // update all digit multipliers

--- a/index.html
+++ b/index.html
@@ -150,7 +150,7 @@
 			
 			player.pluses = player.pluses.add(getPluses()); // give player gained pluses
 			if(player.u2) { // if he has upgrade 2, make sure to reset mults from it.
-				for(var i=0; i<=player.digitShifst; i++) {
+				for(var i=0; i<=player.digitShifts; i++) {
 					player.digitMults[i] = player.digitMults[i].divide(Decimal.pow(1.04,player.digitAmounts[i]));
 				}
 			}


### PR DESCRIPTION
This update makes locked buttons fade out so you can easily see they can't be bought. It also adds a new notation and support for numbers greater than e3003 in Standard. Also I fixed some typos and a few other things I can't remember at the moment.

I don't know which branch to put this in, so I'm just going to use this one. It won't automatically merge for some reason, even though it could last time I checked, which was only a few hours ago. Sorry if merging this is extremely annoying.

The Multiplication upgrades don't fade out yet, I'll work on that next.